### PR TITLE
Add support for XML element shortform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
 obj
+out
 adalib
 *.ali

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-GNATPROVE_OPTS = --prover=z3,cvc4,altergo -j0 --codepeer=on --output-header
+CODEPEER ?= on
+GNATPROVE_OPTS = --prover=z3,cvc4,altergo -j0 --codepeer=$(CODEPEER) --output-header
 GPRBUILD_OPTS = -gnata -p
 
 all:

--- a/examples/exec.gpr
+++ b/examples/exec.gpr
@@ -4,6 +4,7 @@ project Exec
 is
    for Main use ("exec.adb");
    for Object_Dir use "../obj";
+   for Exec_Dir use "../out";
 
    package Builder is
       for Global_Configuration_Pragmas use "../spark.adc";

--- a/examples/simple.gpr
+++ b/examples/simple.gpr
@@ -4,6 +4,7 @@ project Simple
 is
    for Main use ("simple.adb");
    for Object_Dir use "../obj";
+   for Exec_Dir use "../out";
 
    package Builder is
       for Global_Configuration_Pragmas use "../spark.adc";

--- a/sxml.adb
+++ b/sxml.adb
@@ -90,7 +90,7 @@ is
    is
       Index : Natural;
    begin
-      return Result : Subtree_Type (1 .. Children'Length + 2)
+      return Result : Subtree_Type (1 .. Children'Length + 2) := (others => Null_Node)
       do
          Result (Result'First) := (Kind => Kind_Element_Open, Name => To_Name (Name));
          Index := 2;
@@ -214,6 +214,7 @@ is
    begin
       return Result : String (1 .. Text_Len (Tree)) := (others => Character'Val (0))
       do
+         Fill_Result :
          for I in Tree'Range
          loop
             case Tree (I).Kind
@@ -240,9 +241,9 @@ is
                when Kind_Attr_Float =>
                   Append (Result, " " & To_String (Tree (I).Name) & "=""" & To_String (Tree (I).Float_Value) & """");
                when Kind_Invalid =>
-                  return;
+                  exit Fill_Result;
             end case;
-         end loop;
+         end loop Fill_Result;
       end return;
    end To_String;
 

--- a/sxml.adb
+++ b/sxml.adb
@@ -148,26 +148,40 @@ is
 
    function Text_Len (Tree : Subtree_Type) return Natural
    is
-      Result : Natural := 0;
+      Is_Open : Boolean := False;
+      Result  : Natural := 0;
    begin
       for E of Tree
       loop
-         Result := Result + To_String (E.Name)'Length;
-         case E.Kind
-         is
+         declare
+            Name_Len : constant Natural := To_String (E.Name)'Length;
+         begin
+            Result := Result + Name_Len;
+            case E.Kind
+            is
             when Kind_Element_Open =>
-               Result := Result + 2;
+               Result  := Result + Name_Len + 2;
+               Is_Open := True;
             when Kind_Element_Close =>
-               Result := Result + 3;
+               if Is_Open then
+                  Result := Result + 1;
+               else
+                  Result := Result + Name_Len + 3;
+               end if;
+               Is_Open := False;
             when Kind_Attr_Integer =>
-               Result := Result + To_String (E.Integer_Value)'Length + 4;
+               Result := Result + Name_Len +
+                 To_String (E.Integer_Value)'Length + 4;
             when Kind_Attr_String =>
-               Result := Result + To_String (E.String_Value)'Length + 4;
+               Result := Result + Name_Len + To_String
+                 (E.String_Value)'Length + 4;
             when Kind_Attr_Float =>
-               Result := Result + To_String (E.Float_Value)'Length + 4;
+               Result := Result + Name_Len + To_String
+                 (E.Float_Value)'Length + 4;
             when Kind_Invalid =>
                return 0;
-         end case;
+            end case;
+         end;
       end loop;
       return Result;
    end Text_Len;
@@ -209,15 +223,16 @@ is
                   then
                      Append (Result, ">");
                   end if;
-                  Is_Open := True;
+                  Is_Open   := True;
                   Append (Result, "<" & To_String (Tree (I).Name));
                when Kind_Element_Close =>
                   if Is_Open
                   then
                      Is_Open := False;
-                     Append (Result, ">");
+                     Append (Result, "/>");
+                  else
+                     Append (Result, "</" & To_String (Tree (I).Name) & ">");
                   end if;
-                  Append (Result, "</" & To_String (Tree (I).Name) & ">");
                when Kind_Attr_Integer =>
                   Append (Result, " " & To_String (Tree (I).Name) & "=""" & To_String (Tree (I).Integer_Value) & """");
                when Kind_Attr_String =>


### PR DESCRIPTION
These changes simplify XML element nodes that have no other elements as children and thus do not required an explicit closing tag.

Also, provide a simple way to controle CodePeer use for proofs via an environment variable.