### PR TITLE
Improve path queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ all:
 test: SXML.gpr
 	$(CHECK)gnatcheck -P SXML
 	@gprbuild $(GPRBUILD_OPTS) -P tests/execute/tests
-	@gnatprove $(GNATPROVE_OPTS) -P tests/prove/prove
 	@obj/tests
+
+prove:
+	@gnatprove $(GNATPROVE_OPTS) -P SXML
+	@gnatprove $(GNATPROVE_OPTS) -P tests/prove/prove
 
 doc: doc/api/index.html
 

--- a/src/sxml-query.adb
+++ b/src/sxml-query.adb
@@ -238,6 +238,88 @@ is
       Get_String (Document, Add (State.Offset, Val), Result, Data, Last);
    end Value;
 
+   -----------------
+   -- Split_Query --
+   -----------------
+
+   type Position_Type (Valid : Boolean) is
+   record
+      case Valid is
+         when True =>
+            Name_First  : Natural;
+            Name_Last   : Natural;
+            Value_First : Natural;
+            Value_Last  : Natural;
+         when others =>
+            null;
+      end case;
+   end record;
+
+   function Split_Query (Query_String :     String;
+                         First        :     Natural) return Position_Type
+    with
+       Pre => First > Query_String'First and
+              First <= Query_String'Last and
+              Query_String'Last < Natural'Last and
+              Query_String'Length > 0,
+       Post => (if Split_Query'Result.Valid
+                then Split_Query'Result.Name_First  >= Query_String'First and
+                     Split_Query'Result.Name_Last   <= Query_String'Last and
+                     Split_Query'Result.Value_First >= Query_String'First and
+                     Split_Query'Result.Value_Last  <= Query_String'Last);
+
+   function Split_Query (Query_String :     String;
+                         First        :     Natural) return Position_Type
+   is
+      Eq_Pos : Natural := Query_String'Last;
+      Len    : constant Natural := Query_String'Last - First + 1;
+   begin
+      --  Missing opening or closing bracket
+      if Len < 2 or else
+         Query_String (First) /= '[' or else
+         Query_String (Query_String'Last)  /= ']'
+      then
+         return (Valid => False);
+      end if;
+
+      --  Empty expression always matches
+      if Len = 2
+      then
+         return (Valid       => True,
+                 Name_First  => Query_String'Last,
+                 Name_Last   => Query_String'First,
+                 Value_First => Query_String'Last,
+                 Value_Last  => Query_String'First);
+      end if;
+
+      if Query_String (First + 1) /= '@'
+      then
+         return (Valid => False);
+      end if;
+
+      --  Find position and ensure single occurrence of '='
+      for I in First .. Query_String'Last
+      loop
+         pragma Loop_Invariant (Eq_Pos in Query_String'Range);
+         if Eq_Pos /= Query_String'Last and Query_String (I) = '='
+         then
+            return (Valid => False);
+         end if;
+         if Query_String (I) = '='
+         then
+            Eq_Pos := I;
+         end if;
+      end loop;
+
+      return
+         (Valid       => True,
+          Name_First  => First + 2,
+          Name_Last   => Eq_Pos - 1,
+          Value_First => Eq_Pos + 1,
+          Value_Last  => Query_String'Last - 1);
+
+   end Split_Query;
+
    ----------
    -- Path --
    ----------
@@ -248,6 +330,7 @@ is
    is
       First : Natural;
       Last  : Natural := Query_String'First - 1;
+      Pos_Valid : Boolean := False;
       Result_State : State_Type := State;
    begin
 
@@ -258,6 +341,7 @@ is
 
       loop
          exit when Last >= Query_String'Last - 1;
+         pragma Assert (Last < Query_String'Last - 1);
          First := Last + 2;
          Last  := First;
 
@@ -278,7 +362,9 @@ is
             pragma Loop_Invariant (Last <= Query_String'Last);
 
             exit when Last >= Query_String'Last or else
-                      Query_String (Last + 1) = '/';
+                      (Query_String (Last + 1) = '/' or
+                       Query_String (Last + 1) = '[' or
+                       Query_String (Last + 1) = ']');
             Last := Last + 1;
          end loop;
 
@@ -287,14 +373,34 @@ is
             exit;
          end if;
 
-         Result_State := Find_Sibling (Result_State, Document, Query_String (First .. Last));
+         if Last < Query_String'Last and then Query_String (Last + 1) = '['
+         then
+            declare
+               Pos : constant Position_Type := Split_Query (Query_String => Query_String,
+                                                            First        => Last + 1);
+            begin
+               if not Pos.Valid
+               then
+                  return (Result => Result_Invalid);
+               end if;
+               Result_State := Find_Sibling (State           => Result_State,
+                                             Document        => Document,
+                                             Sibling_Name    => Query_String (First .. Last),
+                                             Attribute_Name  => Query_String (Pos.Name_First .. Pos.Name_Last),
+                                             Attribute_Value => Query_String (Pos.Value_First .. Pos.Value_Last));
+               Pos_Valid := True;
+            end;
+         else
+            Result_State := Find_Sibling (Result_State, Document, Query_String (First .. Last));
+         end if;
+
          if Result_State.Result /= Result_OK
          then
             return (Result => Result_Not_Found);
          end if;
 
          --  Query string processed
-         if Last = Query_String'Last
+         if Pos_Valid or Last = Query_String'Last
          then
             return Result_State;
          end if;
@@ -315,8 +421,8 @@ is
 
    function Find_Attribute (State           : State_Type;
                             Document        : Document_Type;
-                            Attribute_Name  : Content_Type := "*";
-                            Attribute_Value : Content_Type := "*") return State_Type
+                            Attribute_Name  : String := "*";
+                            Attribute_Value : String := "*") return State_Type
    is
       Result          : Result_Type;
       Result_State    : State_Type := Attribute (State, Document);
@@ -335,30 +441,39 @@ is
          pragma Loop_Variant (Increases => Offset (Result_State));
          pragma Loop_Invariant (Is_Valid (Document, Result_State));
          pragma Loop_Invariant (Is_Attribute (Document, Result_State));
-         pragma Assert (Valid_Content (1, Attribute_Name'Length));
+         pragma Loop_Invariant (Valid_Content (Scratch_Buffer'First, Scratch_Buffer'Last));
 
-         if Attribute_Name = "*"
+         if Attribute_Name = "*" or Attribute_Name = ""
          then
             Attribute_Found := True;
          else
+            pragma Assert (Valid_Content (1, Attribute_Name'Length));
             Name (Result_State, Document, Result, Scratch_Buffer (1 .. Attribute_Name'Length), Last);
             Attribute_Found := Result = Result_OK and then
-                               Last = Attribute_Name'Length and then
-                               Scratch_Buffer (1 .. Last) = Attribute_Name;
+               Last = Attribute_Name'Length and then
+               Scratch_Buffer (1 .. Last) = Attribute_Name;
          end if;
 
          if Attribute_Found
          then
-            if Attribute_Value = "*"
+            if Attribute_Value = "*" or Attribute_Value = ""
             then
                Value_Matches := True;
+            elsif not Is_Valid_Value (Result_State, Document)
+            then
+               Value_Matches := False;
             else
                declare
                   R : Result_Type;
                   L : Natural;
                begin
-                  Value (Result_State, Document, R, Scratch_Buffer, L);
-                  Value_Matches := R = Result_OK and Scratch_Buffer (1 .. L) = Attribute_Value;
+                  Value (State    => Result_State,
+                         Document => Document,
+                         Result   => R,
+                         Data     => Scratch_Buffer,
+                         Last     => L);
+                  Value_Matches := R = Result_OK and then
+                                   Scratch_Buffer (1 .. L) = Attribute_Value;
                end;
             end if;
             if Value_Matches
@@ -379,11 +494,11 @@ is
    function Find_Sibling (State           : State_Type;
                           Document        : Document_Type;
                           Sibling_Name    : Content_Type;
-                          Attribute_Name  : Content_Type := "*";
-                          Attribute_Value : Content_Type := "*") return State_Type
+                          Attribute_Name  : String := "*";
+                          Attribute_Value : String := "*") return State_Type
    is
       Result_State   : State_Type := State;
-      Attr_State     : State_Type := State;
+      Attr_State     : State_Type;
       Result         : Result_Type;
       Last           : Natural;
       Scratch_Buffer : String (1 .. Scratch_Buffer_Length) := (others => ASCII.NUL);
@@ -405,19 +520,22 @@ is
                Scratch_Buffer (1 .. Last) = Sibling_Name
             then
                Attr_State := Find_Attribute (Result_State, Document, Attribute_Name, Attribute_Value);
-               if (Attribute_Name = "*" and Attribute_Value = "*") or Attr_State.Result = Result_OK
+               if ((Attribute_Name = "*" or Attribute_Name = "") and
+                   (Attribute_Value = "*"  or Attribute_Value = "")) or
+                  Attr_State.Result = Result_OK
                then
                   return Result_State;
                end if;
             end if;
          end if;
-         Result_State := Sibling (Result_State, Document);
 
          pragma Loop_Variant (Increases => Result_State.Offset);
-         pragma Loop_Invariant (Result_State.Result = Result_OK);
          pragma Loop_Invariant (Is_Valid (Document, Result_State));
-         pragma Loop_Invariant (Offset (Result_State) > Offset (Result_State'Loop_Entry));
+         pragma Loop_Invariant (Result_State.Result = Result_OK);
+         pragma Loop_Invariant (Offset (Result_State) >= Offset (Result_State'Loop_Entry));
          pragma Loop_Invariant (Is_Open (Document, Result_State) or Is_Content (Document, Result_State));
+
+         Result_State := Sibling (Result_State, Document);
       end loop;
 
       return (Result => Result_Not_Found);

--- a/src/sxml-query.adb
+++ b/src/sxml-query.adb
@@ -313,9 +313,10 @@ is
    -- Find_Attribute --
    --------------------
 
-   function Find_Attribute (State          : State_Type;
-                            Document       : Document_Type;
-                            Attribute_Name : Content_Type) return State_Type
+   function Find_Attribute (State           : State_Type;
+                            Document        : Document_Type;
+                            Attribute_Name  : Content_Type;
+                            Attribute_Value : Content_Type := "*") return State_Type
    is
       Result         : Result_Type;
       Result_State   : State_Type := Attribute (State, Document);
@@ -339,7 +340,21 @@ is
             Last = Attribute_Name'Length and then
             Scratch_Buffer (1 .. Last) = Attribute_Name
          then
-            return Result_State;
+            if Attribute_Value = "*"
+            then
+               return Result_State;
+            else
+               declare
+                  R : Result_Type;
+                  L : Natural;
+               begin
+                  Value (Result_State, Document, R, Scratch_Buffer, L);
+                  if R = Result_OK and Scratch_Buffer (1 .. L) = Attribute_Value
+                  then
+                     return Result_State;
+                  end if;
+               end;
+            end if;
          end if;
          Result_State := Next_Attribute (Result_State, Document);
       end loop;

--- a/src/sxml-query.ads
+++ b/src/sxml-query.ads
@@ -154,11 +154,15 @@ is
    -- Find_Sibling --
    ------------------
 
-   function Find_Sibling (State        : State_Type;
-                          Document     : Document_Type;
-                          Sibling_Name : Content_Type) return State_Type
+   function Find_Sibling (State           : State_Type;
+                          Document        : Document_Type;
+                          Sibling_Name    : Content_Type;
+                          Attribute_Name  : Content_Type := "*";
+                          Attribute_Value : Content_Type := "*") return State_Type
    with
       Pre  => Valid_Content (Sibling_Name'First, Sibling_Name'Last) and then
+              Valid_Content (Attribute_Name'First, Attribute_Name'Last) and then
+              Valid_Content (Attribute_Value'First, Attribute_Value'Last) and then
               State.Result = Result_OK and then
               Is_Valid (Document, State) and then
                (Is_Open (Document, State) or
@@ -257,7 +261,7 @@ is
 
    function Find_Attribute (State           : State_Type;
                             Document        : Document_Type;
-                            Attribute_Name  : Content_Type;
+                            Attribute_Name  : Content_Type := "*";
                             Attribute_Value : Content_Type := "*") return State_Type
    with
       Pre => State.Result = Result_OK and then
@@ -269,6 +273,7 @@ is
    --  @param State           Current state
    --  @param Document        Document
    --  @param Attribute_Name  Name to search for
+   --  @param Attribute_Value Value to match for
    --  @return                Result of operation
 
    ----------

--- a/src/sxml-query.ads
+++ b/src/sxml-query.ads
@@ -157,12 +157,10 @@ is
    function Find_Sibling (State           : State_Type;
                           Document        : Document_Type;
                           Sibling_Name    : Content_Type;
-                          Attribute_Name  : Content_Type := "*";
-                          Attribute_Value : Content_Type := "*") return State_Type
+                          Attribute_Name  : String := "*";
+                          Attribute_Value : String := "*") return State_Type
    with
       Pre  => Valid_Content (Sibling_Name'First, Sibling_Name'Last) and then
-              Valid_Content (Attribute_Name'First, Attribute_Name'Last) and then
-              Valid_Content (Attribute_Value'First, Attribute_Value'Last) and then
               State.Result = Result_OK and then
               Is_Valid (Document, State) and then
                (Is_Open (Document, State) or
@@ -226,7 +224,9 @@ is
              State.Result = Result_OK and then
              Is_Valid (Document, State) and then
              Is_Attribute (Document, State) and then
-             Is_Valid_Value (State, Document);
+             Is_Valid_Value (State, Document),
+      Post => (if Result = Result_OK
+               then Last in Data'Range);
    --  Return value for current attribute
    --
    --  @param State     Current state
@@ -261,8 +261,8 @@ is
 
    function Find_Attribute (State           : State_Type;
                             Document        : Document_Type;
-                            Attribute_Name  : Content_Type := "*";
-                            Attribute_Value : Content_Type := "*") return State_Type
+                            Attribute_Name  : String := "*";
+                            Attribute_Value : String := "*") return State_Type
    with
       Pre => State.Result = Result_OK and then
              Is_Valid (Document, State) and then

--- a/src/sxml-query.ads
+++ b/src/sxml-query.ads
@@ -255,9 +255,10 @@ is
    -- Find_Attribute --
    --------------------
 
-   function Find_Attribute (State          : State_Type;
-                            Document       : Document_Type;
-                            Attribute_Name : Content_Type) return State_Type
+   function Find_Attribute (State           : State_Type;
+                            Document        : Document_Type;
+                            Attribute_Name  : Content_Type;
+                            Attribute_Value : Content_Type := "*") return State_Type
    with
       Pre => State.Result = Result_OK and then
              Is_Valid (Document, State) and then

--- a/src/sxml-stack.adb
+++ b/src/sxml-stack.adb
@@ -92,7 +92,9 @@ is
    procedure Init
    is
    begin
-      S := (others => Null_Element);
+      --  We need to give explicit bounds here, as a direct assignment to S
+      --  causes a buffer overflow due to a compiler bug, cf. RB29-053
+      S (S'First .. S'Last) := (others => Null_Element);
       Index := S'First;
    end Init;
 

--- a/src/sxml.ads
+++ b/src/sxml.ads
@@ -282,6 +282,8 @@ is
    with
       Pre      => Start < Document'Length and
                   Valid_Content (Data'First, Data'Last),
+      Post     => (if Result = Result_OK
+                   then Last in Data'Range),
       Annotate => (Gnatprove, Terminating);
    --  Extract string at given position
    --

--- a/tests/data/attribute_value.xml
+++ b/tests/data/attribute_value.xml
@@ -6,4 +6,13 @@
       <elem id="4" value="d"/>
       <elem id="4" value="e"/>
    </child>
+
+   <child2>
+      <elem id="1" value="a"/>
+      <elem id="2" value="b"/>
+      <elem id="3" value="c"/>
+      <elem id="4" value="d"/>
+      <elem id="4" value="x" foo="bar" />
+      <elem id="4" value="e"/>
+   </child2>
 </root>

--- a/tests/data/attribute_value.xml
+++ b/tests/data/attribute_value.xml
@@ -1,0 +1,9 @@
+<root>
+   <child>
+      <elem id="1" value="a"/>
+      <elem id="2" value="b"/>
+      <elem id="3" value="c"/>
+      <elem id="4" value="d"/>
+      <elem id="4" value="e"/>
+   </child>
+</root>

--- a/tests/execute/sxml_query_tests.adb
+++ b/tests/execute/sxml_query_tests.adb
@@ -359,7 +359,11 @@ package body SXML_Query_Tests is
 
       Attr := Find_Attribute (State, Context.all, "id");
       Assert (Attr.Result = Result_OK, "Invalid attribute (1): " & Attr.Result'Img);
-      Assert (Value (Attr, Context.all) = "1", "Invalid value");
+      Assert (Value (Attr, Context.all) = "1", "Invalid value (1)");
+
+      Attr := Find_Attribute (State, Context.all, "id", "");
+      Assert (Attr.Result = Result_OK, "Invalid attribute (1b): " & Attr.Result'Img);
+      Assert (Value (Attr, Context.all) = "1", "Invalid value (1b)");
 
       Attr := Find_Attribute (State, Context.all, "id", "1");
       Assert (Attr.Result = Result_OK, "Invalid attribute (2): " & Attr.Result'Img);
@@ -406,14 +410,61 @@ package body SXML_Query_Tests is
       Assert (Elem.Result = Result_Not_Found, "Expected Result_Not_Found, got " & Elem.Result'Img);
 
       Elem := Find_Sibling (State, Context.all, "elem", "value", "e");
-      Assert (Elem.Result = Result_OK, "Element not found (3): " & Elem.Result'Img);
+      Assert (Elem.Result = Result_OK, "Element not found (4): " & Elem.Result'Img);
       Attr := Find_Attribute (Elem, Context.all, "value");
-      Assert (Value (Attr, Context.all) = "e", "Invalid attribute (3)" & Value (Attr, Context.all));
+      Assert (Value (Attr, Context.all) = "e", "Invalid attribute (4)" & Value (Attr, Context.all));
 
       Elem := Find_Sibling (State, Context.all, "elem", "id", "invalid");
       Assert (Elem.Result = Result_Not_Found, "Expected Result_Not_Found, got " & Elem.Result'Img);
 
    end Test_Find_Node_By_Attribute;
+
+   ---------------------------------------------------------------------------
+
+   procedure Test_Path_Query_With_Attribute (T : in out Test_Cases.Test_Case'Class)
+   is
+      Context  : access SXML.Document_Type := new SXML.Document_Type (1 .. 1000000);
+      Position : Natural;
+   begin
+      declare
+         Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[@id=3]", Position);
+         Attr : State_Type;
+      begin
+         Assert (Elem.Result = Result_OK, "Element not found: " & Elem.Result'Img & " at" & Position'Img);
+         Attr := Find_Attribute (Elem, Context.all, "value");
+         Assert (Value (Attr, Context.all) = "c", "Invalid value, got: " & Value (Attr, Context.all));
+      end;
+
+      declare
+         Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[@foo]", Position);
+         Attr : State_Type;
+      begin
+         Assert (Elem.Result = Result_OK, "Element not found: " & Elem.Result'Img & " at" & Position'Img);
+         Attr := Find_Attribute (Elem, Context.all, "value");
+         Assert (Value (Attr, Context.all) = "x", "Invalid value");
+      end;
+
+      declare
+         Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[", Position);
+      begin
+         Assert (Elem.Result = Result_Invalid, "Expected Result_Invalid, got " & Elem.Result'Img);
+      end;
+
+      declare
+         Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[x]", Position);
+      begin
+         Assert (Elem.Result = Result_Invalid, "Expected Result_Invalid, got " & Elem.Result'Img);
+      end;
+
+      declare
+         Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[]", Position);
+         Attr : State_Type;
+      begin
+         Assert (Elem.Result = Result_OK, "Element not found: " & Elem.Result'Img & " at" & Position'Img);
+         Attr := Find_Attribute (Elem, Context.all, "value");
+         Assert (Value (Attr, Context.all) = "a", "Invalid value");
+      end;
+   end Test_Path_Query_With_Attribute;
 
    ---------------------------------------------------------------------------
 
@@ -437,6 +488,7 @@ package body SXML_Query_Tests is
       Register_Routine (T, Test_Path_Query_Long'Access, "Long path query");
       Register_Routine (T, Test_Attribute_Value'Access, "Attribute value");
       Register_Routine (T, Test_Find_Node_By_Attribute'Access, "Find node by attribute value");
+      Register_Routine (T, Test_Path_Query_With_Attribute'Access, "Path query with attribute");
    end Register_Tests;
 
    ---------------------------------------------------------------------------

--- a/tests/execute/sxml_query_tests.adb
+++ b/tests/execute/sxml_query_tests.adb
@@ -81,7 +81,7 @@ package body SXML_Query_Tests is
       N     : String       := Name (State, Doc);
    begin
       Assert (N = "config", "Unexpected name: """ & N & """ (expected ""config"")");
-	end Test_Query_Node_Name;
+   end Test_Query_Node_Name;
 
    ---------------------------------------------------------------------------
 
@@ -99,7 +99,7 @@ package body SXML_Query_Tests is
       begin
          Assert (Child_Name = "child", "Unexpected name: """ & Child_Name & """ (expected ""config"")");
       end;
-	end Test_Query_Child;
+   end Test_Query_Child;
 
    ---------------------------------------------------------------------------
 
@@ -112,7 +112,7 @@ package body SXML_Query_Tests is
    begin
       State := Child (State, Doc);
       Assert (State.Result = Result_Not_Found, "Expected no child");
-	end Test_Query_No_Child;
+   end Test_Query_No_Child;
 
    ---------------------------------------------------------------------------
 
@@ -134,7 +134,7 @@ package body SXML_Query_Tests is
       Assert (Name (State, Doc) = "child3", "Invalid third child");
       State := Sibling (State, Doc);
       Assert (State.Result = Result_Not_Found, "Expected no more children");
-	end Test_Query_All_Children;
+   end Test_Query_All_Children;
 
    ---------------------------------------------------------------------------
 
@@ -149,7 +149,7 @@ package body SXML_Query_Tests is
       Assert (State.Result = Result_OK, "First child not found");
       State := Find_Sibling (State, Doc, "child2");
       Assert (Name (State, Doc) = "child2", "Invalid child");
-	end Test_Query_Find_Sibling;
+   end Test_Query_Find_Sibling;
 
    ---------------------------------------------------------------------------
 
@@ -165,10 +165,11 @@ package body SXML_Query_Tests is
    begin
       State := Child (State, Doc);
       Assert (State.Result = Result_OK, "First child not found");
+      Assert (Name (State, Doc) = "child1", "First child has wrong value");
       State := Find_Sibling (State, Doc, "child2");
       Assert (State.Result = Result_OK, "Second child not found: " & State.Result'Img);
       Assert (Name (State, Doc) = "child2", "Invalid child: " & Name (State, Doc));
-	end Test_Query_Find_Sibling_With_Content;
+   end Test_Query_Find_Sibling_With_Content;
 
    ---------------------------------------------------------------------------
 
@@ -183,7 +184,7 @@ package body SXML_Query_Tests is
       Assert (State.Result = Result_OK, "First child not found");
       State := Find_Sibling (State, Doc, "child1");
       Assert (Name (State, Doc) = "child1", "Invalid child");
-	end Test_Query_Find_First_Sibling;
+   end Test_Query_Find_First_Sibling;
 
    ---------------------------------------------------------------------------
 
@@ -203,7 +204,7 @@ package body SXML_Query_Tests is
          Assert (N = "attribute1", "Unexpected name: """ & N & """ (expected ""attribute1"")");
          Assert (V = "value1", "Unexpected value: """ & V & """ (expected ""value1"")");
       end;
-	end Test_Query_Attribute;
+   end Test_Query_Attribute;
 
    ---------------------------------------------------------------------------
 
@@ -234,8 +235,6 @@ package body SXML_Query_Tests is
       Assert (State.Result = Result_OK, "Invalid attribute");
       Assert (Name (State, Doc) = "attribute4", "Unexpected name");
       Assert (Value (State, Doc) = "value4", "Unexpected name");
-      State := Next_Attribute (State, Doc);
-      Assert (State.Result = Result_Not_Found, "Expected end of attributes");
    end Test_Query_Multiple_Attributes;
 
    ---------------------------------------------------------------------------
@@ -307,7 +306,7 @@ package body SXML_Query_Tests is
    begin
       Assert (State.Result = Result_OK, "Invalid result: " & State.Result'Img & " at" & Position'Img);
       Assert (Name (State, Context.all) = "ClinicalDocument", "Invalid name");
-	end Test_Path_Query_Simple;
+   end Test_Path_Query_Simple;
 
    ---------------------------------------------------------------------------
 
@@ -321,7 +320,7 @@ package body SXML_Query_Tests is
                      Position);
    begin
       Assert (State.Result = Result_Not_Found, "Invalid result: " & State.Result'Img & " at" & Position'Img);
-	end Test_Path_Query_Simple_Missing;
+   end Test_Path_Query_Simple_Missing;
 
    ---------------------------------------------------------------------------
 
@@ -340,7 +339,7 @@ package body SXML_Query_Tests is
       State := Find_Attribute (State, Context.all, "root");
       Assert (State.Result = Result_OK, "Invalid attribute: " & State.Result'Img);
       Assert (Value (State, Context.all) = "2.16.840.1.113883.3.140.1.0.6.4", "Invalid value");
-	end Test_Path_Query_Long;
+   end Test_Path_Query_Long;
 
    ---------------------------------------------------------------------------
 
@@ -370,7 +369,51 @@ package body SXML_Query_Tests is
 
       Attr := Find_Attribute (State, Context.all, "id", "invalid");
       Assert (Attr.Result = Result_Not_Found, "Expected Result_Not_Found, got: " & Attr.Result'Img);
-	end Test_Attribute_Value;
+
+      Attr := Find_Attribute (State, Context.all);
+      Assert (Attr.Result = Result_OK, "Invalid attribute (3): " & Attr.Result'Img);
+      Assert (Name (Attr, Context.all) = "id", "Invalid attribute name: " & Name (Attr, Context.all));
+      Assert (Value (Attr, Context.all) = "1", "Invalid attribute value: " & Value (Attr, Context.all));
+   end Test_Attribute_Value;
+
+   ---------------------------------------------------------------------------
+
+   procedure Test_Find_Node_By_Attribute (T : in out Test_Cases.Test_Case'Class)
+   is
+      Context : access SXML.Document_Type := new SXML.Document_Type (1 .. 1000000);
+      Position : Natural;
+      Elem, Attr : State_Type;
+      State : State_Type :=
+         Path_Query (Context.all,
+                     "tests/data/attribute_value.xml",
+                     "/root/child/elem",
+                     Position);
+   begin
+      Assert (State.Result = Result_OK, "Invalid result: " & State.Result'Img & " at" & Position'Img);
+      Assert (Name (State, Context.all) = "elem", "Invalid node name: " & Name (State, Context.all));
+
+      Elem := Find_Sibling (State, Context.all, "elem", "id", "2");
+      Assert (Elem.Result = Result_OK, "Element not found (1): " & Elem.Result'Img);
+      Attr := Find_Attribute (Elem, Context.all, "value");
+      Assert (Value (Attr, Context.all) = "b", "Invalid attribute (1): " & Value (Attr, Context.all));
+
+      Elem := Find_Sibling (State, Context.all, "elem", "id", "4");
+      Assert (Elem.Result = Result_OK, "Element not found (2): " & Elem.Result'Img);
+      Attr := Find_Attribute (Elem, Context.all, "value");
+      Assert (Value (Attr, Context.all) = "d", "Invalid attribute (2)" & Value (Attr, Context.all));
+
+      Elem := Find_Sibling (State, Context.all, "elem", "id", "7");
+      Assert (Elem.Result = Result_Not_Found, "Expected Result_Not_Found, got " & Elem.Result'Img);
+
+      Elem := Find_Sibling (State, Context.all, "elem", "value", "e");
+      Assert (Elem.Result = Result_OK, "Element not found (3): " & Elem.Result'Img);
+      Attr := Find_Attribute (Elem, Context.all, "value");
+      Assert (Value (Attr, Context.all) = "e", "Invalid attribute (3)" & Value (Attr, Context.all));
+
+      Elem := Find_Sibling (State, Context.all, "elem", "id", "invalid");
+      Assert (Elem.Result = Result_Not_Found, "Expected Result_Not_Found, got " & Elem.Result'Img);
+
+   end Test_Find_Node_By_Attribute;
 
    ---------------------------------------------------------------------------
 
@@ -393,6 +436,7 @@ package body SXML_Query_Tests is
       Register_Routine (T, Test_Path_Query_Simple_Missing'Access, "Simple path query for missing path");
       Register_Routine (T, Test_Path_Query_Long'Access, "Long path query");
       Register_Routine (T, Test_Attribute_Value'Access, "Attribute value");
+      Register_Routine (T, Test_Find_Node_By_Attribute'Access, "Find node by attribute value");
    end Register_Tests;
 
    ---------------------------------------------------------------------------

--- a/tests/execute/sxml_query_tests.adb
+++ b/tests/execute/sxml_query_tests.adb
@@ -344,6 +344,36 @@ package body SXML_Query_Tests is
 
    ---------------------------------------------------------------------------
 
+   procedure Test_Attribute_Value (T : in out Test_Cases.Test_Case'Class)
+   is
+      Context : access SXML.Document_Type := new SXML.Document_Type (1 .. 1000000);
+      Position : Natural;
+      Attr  : State_Type;
+      State : State_Type :=
+         Path_Query (Context.all,
+                     "tests/data/attribute_value.xml",
+                     "/root/child/elem",
+                     Position);
+   begin
+      Assert (State.Result = Result_OK, "Invalid result: " & State.Result'Img & " at" & Position'Img);
+      Assert (Name (State, Context.all) = "elem", "Invalid node name: " & Name (State, Context.all));
+
+      Attr := Find_Attribute (State, Context.all, "id");
+      Assert (Attr.Result = Result_OK, "Invalid attribute (1): " & Attr.Result'Img);
+      Assert (Value (Attr, Context.all) = "1", "Invalid value");
+
+      Attr := Find_Attribute (State, Context.all, "id", "1");
+      Assert (Attr.Result = Result_OK, "Invalid attribute (2): " & Attr.Result'Img);
+
+      Attr := Find_Attribute (State, Context.all, "value", "a");
+      Assert (Attr.Result = Result_OK, "Invalid value: " & Attr.Result'Img);
+
+      Attr := Find_Attribute (State, Context.all, "id", "invalid");
+      Assert (Attr.Result = Result_Not_Found, "Expected Result_Not_Found, got: " & Attr.Result'Img);
+	end Test_Attribute_Value;
+
+   ---------------------------------------------------------------------------
+
    procedure Register_Tests (T: in out Test_Case) is
       use AUnit.Test_Cases.Registration;
    begin
@@ -362,6 +392,7 @@ package body SXML_Query_Tests is
       Register_Routine (T, Test_Path_Query_Simple'Access, "Simple path query");
       Register_Routine (T, Test_Path_Query_Simple_Missing'Access, "Simple path query for missing path");
       Register_Routine (T, Test_Path_Query_Long'Access, "Long path query");
+      Register_Routine (T, Test_Attribute_Value'Access, "Attribute value");
    end Register_Tests;
 
    ---------------------------------------------------------------------------

--- a/tests/execute/tests.gpr
+++ b/tests/execute/tests.gpr
@@ -2,7 +2,9 @@ with "aunit";
 with "../../SXML";
 
 project Tests is
+   for Create_Missing_Dirs use "True";
    for Source_Dirs use (".", "../debug");
    for Main use ("tests.adb", "benchmark.adb");
+   for Object_Dir use "obj";
    for Exec_Dir use "../../obj";
 end Tests;


### PR DESCRIPTION
Path query interfaces now allows for matching attribute names and values:

```
/parent/child/grandchild[@attribute_name=attributevalue]
```

The query returns the matching *element* - we do not support returning attribute nodes in a query (e.g. `/parent/child/grandchild/@attribute_name`) as this would complicate the postcondition of the `Path` operation in that it would need to reason about the query string referring to an element or an attribute.