### PR TITLE
Support attribute matches at every level of path

### DIFF
--- a/src/sxml-query.ads
+++ b/src/sxml-query.ads
@@ -156,12 +156,11 @@ is
 
    function Find_Sibling (State           : State_Type;
                           Document        : Document_Type;
-                          Sibling_Name    : Content_Type;
+                          Sibling_Name    : String := "*";
                           Attribute_Name  : String := "*";
                           Attribute_Value : String := "*") return State_Type
    with
-      Pre  => Valid_Content (Sibling_Name'First, Sibling_Name'Last) and then
-              State.Result = Result_OK and then
+      Pre  => State.Result = Result_OK and then
               Is_Valid (Document, State) and then
                (Is_Open (Document, State) or
                 Is_Content (Document, State)),

--- a/tests/data/attribute_value.xml
+++ b/tests/data/attribute_value.xml
@@ -15,4 +15,21 @@
       <elem id="4" value="x" foo="bar" />
       <elem id="4" value="e"/>
    </child2>
+
+   <child3>
+      <elem id="1" value="a"/>
+      <elem id="2" value="b"/>
+      <elem id="3" value="c"/>
+      <elem id="4" value="d">
+         <subelem id="2" value="42"/>
+         <subelem id="3" value="43"/>
+         <subelem id="4" value="44"/>
+      </elem>
+      <elem id="4" value="x" foo="bar"/>
+      <elem id="4" value="e">
+         <subelem id="5" value="45"/>
+         <subelem id="6" value="46"/>
+         <subelem id="7" value="47"/>
+      </elem>
+   </child3>
 </root>

--- a/tests/execute/sxml_query_tests.adb
+++ b/tests/execute/sxml_query_tests.adb
@@ -447,7 +447,7 @@ package body SXML_Query_Tests is
       declare
          Elem : State_Type := Path_Query (Context.all, "tests/data/attribute_value.xml", "/root/child2/elem[", Position);
       begin
-         Assert (Elem.Result = Result_Invalid, "Expected Result_Invalid, got " & Elem.Result'Img);
+         Assert (Elem.Result = Result_Invalid, "Expected Result_Not_Found, got " & Elem.Result'Img);
       end;
 
       declare
@@ -465,6 +465,37 @@ package body SXML_Query_Tests is
          Assert (Value (Attr, Context.all) = "a", "Invalid value");
       end;
    end Test_Path_Query_With_Attribute;
+
+   ---------------------------------------------------------------------------
+
+   procedure Test_Path_Query_With_Multiple_Attributes (T : in out Test_Cases.Test_Case'Class)
+   is
+      Context  : access SXML.Document_Type := new SXML.Document_Type (1 .. 1000000);
+      Position : Natural;
+   begin
+      declare
+         Elem : State_Type :=Path_Query (Context.all,
+                                         "tests/data/attribute_value.xml", "/root/child3/elem[@value=d]/subelem[@id=3]",
+                                         Position);
+         Attr : State_Type;
+      begin
+         Assert (Elem.Result = Result_OK, "Element not found: " & Elem.Result'Img & " at" & Position'Img);
+         Attr := Find_Attribute (Elem, Context.all, "value");
+         Assert (Value (Attr, Context.all) = "43", "Invalid value, got: " & Value (Attr, Context.all));
+      end;
+
+      declare
+         Elem : State_Type :=Path_Query (Context.all,
+                                         "tests/data/attribute_value.xml", "/root/child3/elem[@value=e]/subelem[@id=7]",
+                                         Position);
+         Attr : State_Type;
+      begin
+         Assert (Elem.Result = Result_OK, "Element not found: " & Elem.Result'Img & " at" & Position'Img);
+         Attr := Find_Attribute (Elem, Context.all, "value");
+         Assert (Value (Attr, Context.all) = "47", "Invalid value, got: " & Value (Attr, Context.all));
+      end;
+
+   end Test_Path_Query_With_Multiple_Attributes;
 
    ---------------------------------------------------------------------------
 
@@ -489,6 +520,7 @@ package body SXML_Query_Tests is
       Register_Routine (T, Test_Attribute_Value'Access, "Attribute value");
       Register_Routine (T, Test_Find_Node_By_Attribute'Access, "Find node by attribute value");
       Register_Routine (T, Test_Path_Query_With_Attribute'Access, "Path query with attribute");
+      Register_Routine (T, Test_Path_Query_With_Multiple_Attributes'Access, "Path query with multiple attributes");
    end Register_Tests;
 
    ---------------------------------------------------------------------------


### PR DESCRIPTION
Generalize path handling to support attribute matching at every element of the path.

Closes #50 
