### PR TITLE
prove Is_Open or Is_Content for Path post condition

### DIFF
--- a/src/sxml-query.adb
+++ b/src/sxml-query.adb
@@ -321,7 +321,9 @@ is
                 Path_Segment'Result.Result = Result_OK
               then
                 Path_Segment'Result.Offset >= State.Offset
-                and Path_Segment'Result.Offset < Document'Length);
+                and Path_Segment'Result.Offset < Document'Length
+                and (Is_Open (Path_Segment'Result, Document) or else
+                     Is_Content (Path_Segment'Result, Document)));
 
    function Path_Segment (State    : State_Type;
                           Document : Document_Type;

--- a/src/sxml-query.ads
+++ b/src/sxml-query.ads
@@ -352,7 +352,10 @@ is
              and then Query_String'Length > 0
              and then State_Result (State) = Result_OK
              and then Is_Valid (State, Document),
-     Post => (if State_Result (State) = Result_OK then Is_Valid (Path'Result, Document));
+     Post => (if State_Result (State) = Result_OK then Is_Valid (Path'Result, Document))
+             and then (if State_Result (Path'Result) = Result_OK
+                       then Is_Open (Path'Result, Document) or else
+                            Is_Content (Path'Result, Document));
 
 private
 


### PR DESCRIPTION
`SXML.Query.Path` has the valid post condition `Is_Open (Path'Result, Document) or else Is_Content (Path'Result, Document)` if `Path` returns a valid result.